### PR TITLE
fix: fixed weird flash of window on launch

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -1,9 +1,11 @@
 pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Controls.Fusion
+import QtQuick.Window
 import "./qml/components"
 
 ApplicationWindow {
+    id: mainWindow
     visible: true
     width: 1280
     height: 720
@@ -11,6 +13,19 @@ ApplicationWindow {
     minimumHeight: 600
     title: qsTr("Uwide")
     color: "#202020"
+
+    Component.onCompleted: {
+        opacityAnimation.start();
+    }
+
+    PropertyAnimation {
+        id: opacityAnimation
+        target: mainWindow
+        property: "opacity"
+        from: 0
+        to: 1
+        duration: 200
+    }
 
     menuBar: MenuBar {}
 


### PR DESCRIPTION
When launching the app in both Debug and Release, a white flash for the window preceded the displaying of ui contents for the application. Still not 100% sure what caused it but adding a delayed animation to the opacity when the qml is loaded is a viable fix (workaround) for now.